### PR TITLE
Add color diff and diff to output. Remove check std:: options all together

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ COPY entrypoint.sh /entrypoint.sh
 COPY default.cfg /default.cfg
 
 RUN apt-get update
-RUN apt-get -y install curl cmake build-essential python3 git
+RUN apt-get -y install curl cmake build-essential python3 git colordiff
 RUN chmod +x entrypoint.sh
 RUN curl -L -o uncrustify-0.70.1.tar.gz https://github.com/uncrustify/uncrustify/archive/uncrustify-0.70.1.tar.gz
 RUN tar -xzf uncrustify-0.70.1.tar.gz

--- a/README.md
+++ b/README.md
@@ -42,20 +42,3 @@ jobs:
       with: 
         configPath: 'myConfig.cfg'
 ```
-
-Checks for usaged of `std::`: 
-```yml
-on: [ pull_request ]
-
-jobs:
-  cpp_style_check:
-    runs-on: ubuntu-latest
-    name: Check C++ Style
-    steps:
-    - name: Checkout this commit
-      uses: actions/checkout@v2
-    - name: Run style checks
-      uses: coleaeason/actions-uncrustify@v1
-      with: 
-        checkSTD: 'true'
-```

--- a/action.yml
+++ b/action.yml
@@ -5,9 +5,6 @@ inputs:
   configPath:
     description: 'Alternate configuration file to use'
     required: false
-  checkSTD:
-    description: 'Whether or not files should be checked for std:: usage'
-    required: false
 runs:
   using: 'docker'
   image: 'Dockerfile'


### PR DESCRIPTION
This PR adds colordiff output so users can know what to change if they do not have uncrustify locally. Also removes the check std:: option. It was overly complicating the checks and is generally against best practice anyway. 