### PR TITLE
Remove the use of the git command from entrypoint.sh

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,7 +11,7 @@ RED="\u001b[31m"
 GREEN="\u001b[32m"
 RESET="\u001b[0m"
 
-# Maintain support for uncrustify's ENV variable if it's passed in 
+# Maintain support for uncrustify's ENV variable if it's passed in
 # from the actions file. Otherwise the actions file could have the
 # configPath argument set
 if [[ -z $UNCRUSTIFY_CONFIG ]] && [[ -z $INPUT_CONFIGPATH ]]; then
@@ -40,7 +40,7 @@ while read -r FILENAME; do
     RETURN_VAL=$?
 
     # Stop allowing failures again
-    set -e 
+    set -e
 
     if [[ $RETURN_VAL -gt 0 ]]; then
         echo -e "${RED}${OUT} failed style checks.${RESET}"


### PR DESCRIPTION
The use of git command causes the following error.
```text
fatal: detected dubious ownership in repository at '/github/workspace'
```
New diff detection logic is inspired by <https://github.com/jidicula/clang-format-action>.